### PR TITLE
docs: improve the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,6 @@ content-type: application/json; charset=utf-8
 The metrics service can also be run in a docker container:
 
 ```bash
-docker build -t dracor/metrics
+docker build -t dracor/metrics .
 docker run -p 8030:8030 --rm dracor/metrics
 ```

--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ content-type: application/json; charset=utf-8
         }
     },
     "numConnectedComponents": 1,
+    "numEdges": 4,
     "size": 4
 }
 ```

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # DraCor Metrics Service
 
-Micro service calculating network metrics for dracor.org.
+Microservice calculating network metrics for dracor.org.
 
 ## Getting started
 


### PR DESCRIPTION
## Proposed Changes

The Docker build command was not working without the `.`
Also the API returns an additional key/value pair.