### PR TITLE
build: update docker base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.9
+FROM python:3.11-slim
 
 # WORKDIR /home/dracor
 # RUN git clone https://github.com/dracor-org/dracor-metrics.git --branch python


### PR DESCRIPTION
## Proposed Changes

- update the Docker base image to Python 3.11 (slim variant)
- the image size decreases from > 1 GB to ~ 240 MB
- the metrics API still works, I confirmed with the tests from #15 

I guess, that Hug does not work with Python 3.12.