### PR TITLE
bump package version to 1.5.2. 

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dracor-metrics"
-version = "1.4.0"
+version = "1.5.2"
 description = "Microservice calculating network metrics for dracor.org."
 authors = ["Carsten Milling <cmil@hashtable.de>"]
 license = "MIT"


### PR DESCRIPTION
Since v1.4.0 (2024-07-26), the version field in `pyproject.toml` was not bumped, while the git tags v1.5.0 (2025-03-25) and v1.5.1 (2025-06-06) were nonetheless created on commits that still declared version = "1.4.0". Because the service reads its own version via `importlib.metadata.version("dracor-metrics")` (see app/main.py), GET / continues to report {"service":"dracor-metrics","version":"1.4.0"} even when running the `dracor/metrics:1.5.1` Docker image. This PR bumps pyproject.toml to 1.5.2 so the next release self-reports its version truthfully.